### PR TITLE
Run on Node 20 rather than Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,5 +84,5 @@ outputs:
   artifacts:
     description: JSON array with details about found artifacts
 runs:
-  using: node16
+  using: node20
   main: main.js


### PR DESCRIPTION
Node 16 has reached EOL and is deprecated. GitHub is transitioning to Node 20:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/